### PR TITLE
Fixes for 4.06

### DIFF
--- a/pa_ulex.ml
+++ b/pa_ulex.ml
@@ -57,7 +57,7 @@ let decision_table l =
   match (aux max_int [] l : int * 'a list * 'b list) with
     | _,[], _ -> decision l
     | min,((_,max,_)::_ as l1), l2 ->
-	let arr = Array.create (max-min+1) 0 in
+	let arr = Array.make (max-min+1) 0 in
 	List.iter (fun (a,b,i) -> for j = a to b do arr.(j-min) <- i + 1 done) l1;
 	Lte (min-1, Return (-1), Lte (max, Table (min,arr), decision l2))
 

--- a/ulexing.ml
+++ b/ulexing.ml
@@ -42,7 +42,7 @@ let empty_lexbuf = {
 let create f = {
   empty_lexbuf with
     refill = f;
-    buf = Array.create chunk_size 0;
+    buf = Array.make chunk_size 0;
 }
 
 let from_stream s =
@@ -120,7 +120,7 @@ let refill lexbuf =
       Array.blit lexbuf.buf s lexbuf.buf 0 ls
     else begin
       let newlen = (Array.length lexbuf.buf + chunk_size) * 2 in
-      let newbuf = Array.create newlen 0 in
+      let newbuf = Array.make newlen 0 in
       Array.blit lexbuf.buf s newbuf 0 ls;
       lexbuf.buf <- newbuf
     end;

--- a/ulexing.ml
+++ b/ulexing.ml
@@ -187,9 +187,11 @@ let latin1_lexeme_char lexbuf pos =
   to_latin1 (lexeme_char lexbuf pos)
 
 let latin1_sub_lexeme lexbuf pos len =
-  let s = String.create len in
-  for i = 0 to len - 1 do s.[i] <- to_latin1 lexbuf.buf.(lexbuf.start + pos + i) done;
-  s
+  let s = Bytes.create len in
+  for i = 0 to len - 1 do
+    Bytes.set s i (to_latin1 lexbuf.buf.(lexbuf.start + pos + i))
+  done;
+  Bytes.to_string s
 
 let latin1_lexeme lexbuf = 
   latin1_sub_lexeme lexbuf 0 (lexbuf.pos - lexbuf.start)

--- a/utf8.ml
+++ b/utf8.ml
@@ -89,7 +89,7 @@ let rec blit_to_int s spos a apos n =
 
 let to_int_array s pos bytes =
   let n = compute_len s pos bytes in
-  let a = Array.create n 0 in
+  let a = Array.make n 0 in
   blit_to_int s pos a 0 n;
   a
 
@@ -110,7 +110,7 @@ let store b p =
     Buffer.add_char b (Char.chr (0x80 lor (p land 0x3f)))
   )
   else if p <= 0xffff then (
-    if (p >= 0xd800 & p < 0xe000) then raise MalFormed;
+    if (p >= 0xd800 && p < 0xe000) then raise MalFormed;
     Buffer.add_char b (Char.chr (0xe0 lor (p lsr 12)));
     Buffer.add_char b (Char.chr (0x80 lor ((p lsr 6) land 0x3f)));
     Buffer.add_char b (Char.chr (0x80 lor (p land 0x3f)))


### PR DESCRIPTION
The first commit fixes the `-safe-string` business for 4.06, the second commit fixes uses of deprecated functions.
