### PR TITLE
Ulex camlp5

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+-camlp5 version
+     * Backported from camlp4 to camlp5
+
 1.1
      * Generate (more) globally unique identifiers to avoid conflicts when open'ing another module
        processed by ulex (issue reported by Gerd Stolpmann)

--- a/META
+++ b/META
@@ -1,5 +1,5 @@
 version = "1.2"
-requires = "camlp4"
+requires = "camlp5"
 description = "Runtime support for ulex"
 archive(byte) = "ulexing.cma"
 archive(native) = "ulexing.cmxa"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ALL=pa_ulex.cma ulexing.cma
-OCAMLBUILD=ocamlbuild -byte-plugin
+OCAMLBUILD=ocamlbuild -byte-plugin -use-ocamlfind
 
 all::
 	$(OCAMLBUILD) $(ALL)
@@ -12,20 +12,20 @@ install: all
 	cd _build && $(MAKE) -f ../Makefile realinstall
 
 realinstall:
-	ocamlfind install ulex ../META $(wildcard $(MODS:=.mli) $(MODS:=.cmi) $(MODS:=.cmx) pa_ulex.cma ulexing.a ulexing.cma ulexing.cmxa)
+	ocamlfind install ulex-camlp5 ../META $(wildcard $(MODS:=.mli) $(MODS:=.cmi) $(MODS:=.cmx) pa_ulex.cma ulexing.a ulexing.cma ulexing.cmxa)
 
 uninstall:
-	ocamlfind remove ulex
+	ocamlfind remove ulex-camlp5
 
 clean:
 	$(OCAMLBUILD) -clean
 	rm -f *~ *.html *.css *.tar.gz
 
 view_test: all
-	camlp4o -printer ocaml ./_build/pa_ulex.cma test.ml
+	camlp5o pr_o.cmo ./_build/pa_ulex.cma test.ml
 
 run_test:
-	ocamlbuild test.byte
+	$(OCAMLBUILD) test.byte
 	./test.byte
 
 custom_ulexing.byte:

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-Ulex: a OCaml lexer generator for Unicode
+Ulex-camlp5: a OCaml lexer generator for Unicode compiled with camlp5
 
 License:
   Copyright (C) 2003, 2004, 2005, 2006 Alain Frisch
@@ -10,6 +10,8 @@ Author:
 
 --------------------------------------------------------------------------
 Overview
+
+- ulex-camlp5 is a version of ulex compile with camlp5.
 
 - ulex is a lexer generator.
 
@@ -142,7 +144,7 @@ Installation:
 
 Compilation of OCaml files with lexer specifications:
 
-  ocamlfind ocamlc -c -package ulex -syntax camlp4o my_file.ml
+  ocamlfind ocamlc -c -package ulex -syntax camlp5o my_file.ml
 
 When linking, you must also include the ulex package:
   ocamlfind ocamlc -o my_prog -linkpkg -package ulex my_file.cmo
@@ -151,7 +153,7 @@ When linking, you must also include the ulex package:
 2. Without findlib
 
 You can use ulex without findlib. To compile, you need to run the source
-file through the Camlp4 syntax extension pa_ulex.cma. Moreover, you need to 
+file through the Camlp5 syntax extension pa_ulex.cma. Moreover, you need to 
 link the application with the runtime support library for ulex 
 (ulexing.cma / ulexing.cmxa).
 

--- a/_tags
+++ b/_tags
@@ -1,3 +1,3 @@
-"pa_ulex.ml": camlp4orf, use_camlp4
+"pa_ulex.ml": package(camlp5), camlp5orf
 <test.*> or "custom_ulexing.ml": use_ulex
 # true: use_ulex

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -2,7 +2,8 @@ open Ocamlbuild_plugin;;
 open Command;;
 dispatch begin function
 | After_rules ->
-    flag ["ocaml"; "pp"; "use_ulex"] (S[A"camlp4o"; A"pa_ulex.cma"]);
+    flag ["ocaml"; "pp"; "use_ulex"] (S[A"camlp5o"; A"pa_ulex.cma"]);
+    flag ["ocaml"; "pp"; "camlp5orf"] (S[A"camlp5o"; A"pa_macro.cmo"; A"pa_extend.cmo"; A"q_MLast.cmo"]);
     dep ["ocaml"; "ocamldep"; "use_ulex"] ["pa_ulex.cma"];
     ocaml_lib ~tag_name:"use_ulex" "ulexing";
 | _ -> ()

--- a/opam
+++ b/opam
@@ -1,7 +1,7 @@
 opam-version: "1.2"
-name: "ulex"
+name: "ulex-camlp5"
 version: "1.2"
-maintainer: "whitequark@whitequark.org"
+maintainer: "claudio.sacerdoticoen@unibo.it"
 authors: ["Alain.Frisch@inria.fr"]
 homepage: "https://github.com/whitequark/ulex"
 build: [
@@ -13,6 +13,6 @@ remove: [["ocamlfind" "remove" "ulex"]]
 depends: [
   "base-bytes"
   "ocamlfind"
-  "camlp4"
+  "camlp5"
   "ocamlbuild" {build}
 ]

--- a/opam
+++ b/opam
@@ -4,6 +4,7 @@ version: "1.2"
 maintainer: "claudio.sacerdoticoen@unibo.it"
 authors: ["Alain.Frisch@inria.fr"]
 homepage: "https://github.com/whitequark/ulex"
+description: "A OCaml lexer generator for Unicode (backported to camlp5)"
 build: [
   [make]
   [make "all.opt"]


### PR DESCRIPTION
Dear Whitequark,

here is a pull request to compile ulex with/for camlp5 in place of camlp4. I can only submit a pull request for the main branch, but the intended use is to have a permament branch of master in ulex called ulex-camlp5. What I am asking you is to:
1) create a branch called ulex-camlp5 and pull my ulex-camlp5 onto yours
2) release the ulex-camlp5 package to opam in parallel with the ulex package (that defaults to camlp4)

Cheers,
C.S.C.

P.S.: the current opam/version for ulex is 1.2, but some files like CHANGES still only mention 1.1 on the main branch. You could want to fix that as well.