### PR TITLE
minor fixup for camlp5 8.00

### DIFF
--- a/opam
+++ b/opam
@@ -17,6 +17,6 @@ flags: light-uninstall
 depends: [
   "ocaml" {>="4.02.0"} 
   "ocamlfind" {build}
-  "camlp5"
+  "camlp5" {> "7.99"}
   "ocamlbuild" {build}
 ]

--- a/pa_ulex.ml
+++ b/pa_ulex.ml
@@ -156,7 +156,7 @@ let gen_state auto loc i (part,trans,final) =
     <:expr< match ($lid:p$ (Ulexing.next lexbuf)) 
     with [ $list:cases$ ] >> in
   let ret body =
-    [<:patt< $lid:f$ >>, <:expr< fun lexbuf -> $body$ >>] in
+    [<:patt< $lid:f$ >>, <:expr< fun lexbuf -> $body$ >>, <:vala< [] >>] in
   match best_final final with
     | None -> ret body
     | Some i -> 


### PR DESCRIPTION
there are now PPX attributes in many places, so (for example) what was
a pair (pattern * expression) is now a triple (pattern * expression *
attributes).  Typically the attributes are empty in generated code.
Since this is a spot that can have a meta-variable in quotations, we
have to wrap the empty-list in a "vala".  But again, this is pretty
much a boilerplate value.
